### PR TITLE
support passing an initial route history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.4.0
+
+Support passing an initial route history.
+
 ## 1.3.3
 
 Support passing a parent key.

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.3.3"
+    version: "1.4.0"
   stack_trace:
     dependency: transitive
     description:

--- a/lib/inherited_value.dart
+++ b/lib/inherited_value.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class InheritedValue extends InheritedWidget {
+  final GlobalKey value;
+
+  const InheritedValue({
+    required Widget child,
+    required this.value,
+    Key? key,
+  }) : super(key: key, child: child);
+
+  static InheritedValue? of<S>(BuildContext context) {
+    return context.dependOnInheritedWidgetOfExactType<InheritedValue>();
+  }
+
+  @override
+  bool updateShouldNotify(InheritedValue oldWidget) => value != oldWidget.value;
+}

--- a/lib/stack_router.dart
+++ b/lib/stack_router.dart
@@ -35,11 +35,14 @@ class StackRouter extends StatefulWidget {
   /// updates on Flutter web.
   final bool notifySystemNavigator;
 
+  final List<String> initialHistory;
+
   final void Function(String route)? onRouteChange;
 
   const StackRouter({
     required this.builder,
     this.initialRoute,
+    this.initialHistory = const [],
     this.controller,
     this.onRouteChange,
     this.notifySystemNavigator = true,
@@ -165,7 +168,7 @@ class StackRouterState extends State<StackRouter> {
     // and the history is hydrated with that route.
     if (_currentRoute == null) {
       _currentRoute = widget.initialRoute ?? children![0].route;
-      _routeHistory = [_currentRoute!];
+      _routeHistory = [...widget.initialHistory, _currentRoute!];
       WidgetsBinding.instance.addPostFrameCallback((_) {
         _notifyRouteChange();
       });

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: stack_router
 description: A stack-based routing library using an IndexedStack to route between different widgets. A stack-based routing library using an IndexedStack to route between different widgets.
-version: 1.3.3
+version: 1.4.0
 homepage: https://github.com/danReynolds/stack_router
 
 environment:


### PR DESCRIPTION
An initial route history allows the stack router to support going back from the initial route to whatever set of eagerly built screens (by default) should exist under it in the stack to fully-recreate a flow that was aborted and restarted.